### PR TITLE
Stop using default exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,9 @@ var _cluster = _interopRequireDefault(require("cluster"));
 
 var _yargs = _interopRequireDefault(require("yargs"));
 
-var _master = _interopRequireDefault(require("./master"));
+var _master = require("./master");
 
-var _worker = _interopRequireDefault(require("./worker"));
+var _worker = require("./worker");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -54,14 +54,14 @@ if (_cluster.default.isMaster) {
 
   const on = _cluster.default.on.bind(_cluster.default);
 
-  (0, _master.default)(argv, fork, on);
+  (0, _master.master)(argv, fork, on);
 } else {
   const processSend = process.send;
 
   if (processSend) {
     const on = process.on.bind(process);
     const send = processSend.bind(process);
-    (0, _worker.default)(argv, on, send).catch(err => {
+    (0, _worker.worker)(argv, on, send).catch(err => {
       console.error(err);
       process.exit(1);
     });

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -1,8 +1,8 @@
 // @flow
 
-import worker from "./worker";
+import {worker} from "./worker";
 import type {Argv} from "./types";
-import master from "./master";
+import {master} from "./master";
 import yargs from "yargs";
 import cluster from "cluster";
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = _default;
+exports.master = master;
 
 var _glob = _interopRequireDefault(require("glob"));
 
@@ -246,7 +246,7 @@ function spawnWorkers(fork, state, workerCount) {
  */
 
 
-function _default(argv, fork, on) {
+function master(argv, fork, on) {
   let source = argv.source,
       isWatching = argv.watch,
       verbose = argv.verbose,

--- a/lib/master.js.flow
+++ b/lib/master.js.flow
@@ -17,4 +17,4 @@ declare class Class0 extends events$EventEmitter {
   kill(signal?: string): void;
   send(message: Object, sendHandleOrCallback?: any | Function, callback?: Function): boolean;
 }
-declare export default function(argv: $Exact<{include: ?string, output: string, source: string, target: string, verbose: boolean, watch: boolean, workerCount: number}>, fork: () => Class0, on: (event: string, listener: (worker: Class0) => void) => mixed): $Exact<{erred: boolean, isWatching: boolean, queue: Array<$Exact<{filePath: string, type: "REMOVE_FILE" | "TRANSFORM_FILE"}>>, verbose: boolean, workers: Array<$Exact<{idle: boolean, worker: Class0}>>}>;
+declare export function master(argv: $Exact<{include: ?string, output: string, source: string, target: string, verbose: boolean, watch: boolean, workerCount: number}>, fork: () => Class0, on: (event: string, listener: (worker: Class0) => void) => mixed): $Exact<{erred: boolean, isWatching: boolean, queue: Array<$Exact<{filePath: string, type: "REMOVE_FILE" | "TRANSFORM_FILE"}>>, verbose: boolean, workers: Array<$Exact<{idle: boolean, worker: Class0}>>}>;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = _default;
+exports.worker = worker;
 
 var _core = require("@babel/core");
 
@@ -410,7 +410,7 @@ function writeDataToFile(filePath, data, mode, verbose) {
  */
 
 
-function _default(argv, on, // eslint-disable-line
+function worker(argv, on, // eslint-disable-line
 send) {
   let include = argv.include,
       output = argv.output,

--- a/lib/worker.js.flow
+++ b/lib/worker.js.flow
@@ -6,4 +6,4 @@ import path from "path";
 import mkdirp from "mkdirp";
 import {createReadStream, createWriteStream, readdir, readFile, ReadStream, stat, Stats, unlink, writeFile, WriteStream} from "fs";
 import {transform} from "@babel/core";
-declare export default function(argv: $Exact<{include: ?string, output: string, source: string, target: string, verbose: boolean, watch: boolean, workerCount: number}>, on: (event: string, listener: Function) => mixed, send: (message: any, sendHandleOrCallback?: any, callback?: Function) => void): Promise<void>;
+declare export function worker(argv: $Exact<{include: ?string, output: string, source: string, target: string, verbose: boolean, watch: boolean, workerCount: number}>, on: (event: string, listener: Function) => mixed, send: (message: any, sendHandleOrCallback?: any, callback?: Function) => void): Promise<void>;

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
   "homepage": "https://github.com/dogma-io/nodely#readme",
   "devDependencies": {
     "babel-core": "^7.0.0-0",
-    "babel-jest": "23.0.0",
+    "babel-jest": "23.0.1",
     "codecov": "3.0.2",
-    "jest": "23.0.0",
+    "jest": "23.0.1",
     "jest-serializer-path": "0.1.15",
     "lintly": "0.1.4"
   },

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -33,15 +33,17 @@ describe('index', () => {
     jest.mock('cluster')
     jest.mock('../master')
     jest.mock('../worker', () => {
-      return jest.fn().mockReturnValue(Promise.resolve())
+      return {
+        worker: jest.fn().mockReturnValue(Promise.resolve()),
+      }
     })
 
     jest.spyOn(console, 'error').mockImplementation(() => {})
     jest.spyOn(process, 'exit').mockImplementation(() => {})
 
     cluster = require('cluster')
-    master = require('../master').default
-    worker = require('../worker')
+    master = require('../master').master
+    worker = require('../worker').worker
 
     process.send = jest.fn()
   })

--- a/src/__tests__/master-test.js
+++ b/src/__tests__/master-test.js
@@ -7,7 +7,7 @@ import cluster from 'cluster'
 import glob from 'glob'
 import watch from 'node-watch'
 import {cpus} from 'os'
-import master from '../master'
+import {master} from '../master'
 import {IDLE, TRANSFORM_FILE} from '../actions'
 
 function expectSnapshot(state) {

--- a/src/__tests__/worker-test.js
+++ b/src/__tests__/worker-test.js
@@ -15,7 +15,7 @@ import {
 import mkdirp from 'mkdirp'
 import {Readable, Writable} from 'stream'
 import {REMOVE_FILE, TRANSFORM_FILE} from '../actions'
-import worker from '../worker'
+import {worker} from '../worker'
 
 const TRANSFORM_OPTIONS = Object.freeze({
   presets: [

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,9 @@
 
 import cluster from 'cluster'
 import yargs from 'yargs'
-import master from './master'
+import {master} from './master'
 import type {Argv} from './types'
-import worker from './worker'
+import {worker} from './worker'
 
 const argv: Argv = (yargs
   .option('include', {

--- a/src/master.js
+++ b/src/master.js
@@ -283,7 +283,7 @@ function spawnWorkers(
  * @param fork - fork method
  * @param on - event listener
  */
-export default function(
+export function master(
   argv: Argv,
   fork: () => cluster$Worker,
   on: (event: string, listener: (worker: cluster$Worker) => void) => mixed,

--- a/src/worker.js
+++ b/src/worker.js
@@ -504,7 +504,7 @@ function writeDataToFile(
  * Spin up worker process.
  * @param argv - command line arguments
  */
-export default function(
+export function worker(
   argv: Argv,
   on: (event: string, listener: Function) => mixed, // eslint-disable-line
   send: ProcessSend,


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

*   [ ] #none# - documentation fixes and/or test additions
*   [ ] #patch# - backwards-compatible bug fix
*   [x] #minor# - adding functionality in a backwards-compatible manner
*   [ ] #major# - incompatible API change

# CHANGELOG

*   Stop using default exports as they provide no real benefit and can cause issues with tree-shaking.