### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lintly": "0.2.0"
   },
   "dependencies": {
+    "@babel/core": "7.0.0-beta.49",
     "flow-bin": "0.73.0",
     "glob": "7.1.2",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

*   [ ] #none# - documentation fixes and/or test additions
*   [x] #patch# - backwards-compatible bug fix
*   [ ] #minor# - adding functionality in a backwards-compatible manner
*   [ ] #major# - incompatible API change

# CHANGELOG

*   Add `@babel/core` back to dependencies to not break consumers.
